### PR TITLE
Fix for iOS

### DIFF
--- a/PhoneWordFSharp/PhoneWordFSharp.iOS/AppDelegate.fs
+++ b/PhoneWordFSharp/PhoneWordFSharp.iOS/AppDelegate.fs
@@ -15,16 +15,14 @@ open Xamarin.Forms.Platform.iOS
 type AppDelegate() = 
     inherit FormsApplicationDelegate()
 
-    member val Window = null with get, set
+    override val Window = null with get, set
 
     // This method is invoked when the application is ready to run.
     override this.FinishedLaunching(app, options) = 
         this.Window <- new UIWindow(UIScreen.MainScreen.Bounds)
-
         Xamarin.Forms.Forms.Init()
-
         this.LoadApplication(App())
-        true
+        base.FinishedLaunching(app, options)
 
 module Main = 
     [<EntryPoint>]


### PR DESCRIPTION
The Window property here is not really required and can be removed.
The fix was to ensure that base.FinishedLaunching(app, options) was
called.
